### PR TITLE
add get all shelters endpoint functionality per test

### DIFF
--- a/src/controllers/shelters_controller.ts
+++ b/src/controllers/shelters_controller.ts
@@ -34,3 +34,18 @@ shelterController.get('/:shelterId', async (req: Request, res: Response) => {
     res.status(404).send(err)
   }
 })
+
+shelterController.get('/', async (req: Request, res: Response) => {
+  try {
+    const shelters: Shelter[] = await prisma.shelter.findMany();
+    const sheltersWithRating: ShelterWithRating[] = await Promise.all(
+      shelters.map((shelter) => addRatings(shelter))
+    );
+    const serializedShelters: any[] = sheltersWithRating.map((shelter) =>
+      serializeShelter(shelter)
+    );
+    res.status(200).send({ data: serializedShelters });
+  } catch (err) {
+    res.status(404).send(err);
+  }
+});

--- a/test/requests/shelters/shelterRequest-test.ts
+++ b/test/requests/shelters/shelterRequest-test.ts
@@ -158,3 +158,74 @@ describe('GET shelters/:shelterid', () => {
     expect(res.body.data.attributes.avgStaff).to.equal(7.1);
   })
 })
+
+describe('GET shelters', () => {
+  it('can return all shelters', async () => {
+    const shelterParams1: ShelterPost = {
+      name: 'Golden Sun',
+      streetAddress: '1234 Black St',
+      state: 'NY',
+      zip: 78123,
+      phoneNumber: '2134568765'
+    }
+
+    const shelterParams2: ShelterPost = {
+      name: 'Silver Hand Hounds',
+      streetAddress: '945 Timmult Drive',
+      state: 'CA',
+      zip: 234195,
+      phoneNumber: '1234567890',
+      websiteUrl: 'www.google.com'
+    }
+
+    const shelter1 = await prisma.shelter.create({ data: shelterParams1 })
+    const shelter2 = await prisma.shelter.create({ data: shelterParams2 })
+
+    const review1Params: ReviewPost = {
+      shelterId: shelter1.id,
+      cleanliness: 1.5,
+      safety: 9.5,
+      staff: 8.0
+    }
+
+    const review2Params: ReviewPost = {
+      shelterId: shelter2.id,
+      cleanliness: 3.5,
+      safety: 3.1,
+      staff: 6.2
+    }
+
+    await prisma.review.createMany({ data: [review1Params, review2Params] })
+
+    //Fetch shelter
+    const res = await chai
+    .request(app)
+    .get('/api/v1/shelters')
+
+    expect(res).to.have.status(200);
+    expect(res).to.be.json;
+    expect(res.body).to.have.key('data');
+    expect(res.body.data).to.be.a('array');
+    expect(res.body.data.length).to.equal(2);
+
+    expect(res.body.data[0].type).to.equal('shelter');
+    expect(res.body.data[0].id).to.equal(shelter1.id);
+    expect(res.body.data[0].attributes.name).to.equal('Golden Sun');
+    expect(res.body.data[0].attributes.streetAddress).to.equal('1234 Black St');
+    expect(res.body.data[0].attributes.state).to.equal('NY');
+    expect(res.body.data[0].attributes.zip).to.equal(78123);
+    expect(res.body.data[0].attributes.avgClean).to.equal(1.5);
+    expect(res.body.data[0].attributes.avgSafety).to.equal(9.5);
+    expect(res.body.data[0].attributes.avgStaff).to.equal(8.0);
+
+    expect(res.body.data[1].type).to.equal('shelter');
+    expect(res.body.data[1].id).to.equal(shelter2.id);
+    expect(res.body.data[1].attributes.name).to.equal('Silver Hand Hounds');
+    expect(res.body.data[1].attributes.streetAddress).to.equal('945 Timmult Drive');
+    expect(res.body.data[1].attributes.state).to.equal('CA');
+    expect(res.body.data[1].attributes.zip).to.equal(234195);
+    expect(res.body.data[1].attributes.avgClean).to.equal(3.5);
+    expect(res.body.data[1].attributes.avgSafety).to.equal(3.1);
+    expect(res.body.data[1].attributes.avgStaff).to.equal(6.2);
+  })
+})


### PR DESCRIPTION
Issue #5 

Summary of changes:

- test written for getting all shelters 
- shelters controller added get all shelters function
- types for `Shelter` and `ShelterWithRating` still used in array form

Sample Endpoint Response (if applicable):
```
{
    "data": [
        {
            "id": 1,
            "type": "shelter",
            "attributes": {
                "name": "Golden Sun",
                "streetAddress": "1234 Black St",
                "state": "NY",
                "zip": 78123,
                "websiteUrl": null,
                "phoneNumber": "2134568765",
                "verified": false,
                "avgStaff": null,
                "avgClean": null,
                "avgSafety": null
            }
        },
        {
            "id": 2,
            "type": "shelter",
            "attributes": {
                "name": "Golden Sun",
                "streetAddress": "1234 Black St",
                "state": "NY",
                "zip": 78123,
                "websiteUrl": null,
                "phoneNumber": "2134568765",
                "verified": false,
                "avgStaff": null,
                "avgClean": null,
                "avgSafety": null
            }
        },
        {
            "id": 3,
            "type": "shelter",
            "attributes": {
                "name": "Silver Hand Hounds",
                "streetAddress": "945 Timmult Drive",
                "state": "CA",
                "zip": 234195,
                "websiteUrl": "www.google.com",
                "phoneNumber": "1234567890",
                "verified": false,
                "avgStaff": null,
                "avgClean": null,
                "avgSafety": null
            }
        }
    ]
}
```